### PR TITLE
[CCTRI-169] Support IROH Response API

### DIFF
--- a/tests/unit/api/routing/test_resolution.py
+++ b/tests/unit/api/routing/test_resolution.py
@@ -1,0 +1,39 @@
+from mock import MagicMock
+
+from threatresponse.api.routing import Resolution
+
+
+def test_getattr():
+    owner = object()
+    router = object()
+
+    def check(resolution, route):
+        assert (
+            isinstance(resolution, Resolution) and
+            resolution._owner is owner and
+            resolution._router is router and
+            resolution._route == route
+        )
+
+    resolution = Resolution(owner, router)
+
+    check(resolution, [])
+    check(resolution.x, ['x'])
+    check(resolution.x.y, ['x', 'y'])
+    check(resolution.x.y.z, ['x', 'y', 'z'])
+
+
+def test_call():
+    owner = object()
+    router = MagicMock()
+
+    method = MagicMock()
+    router.resolve.return_value = method
+
+    resolution = Resolution(owner, router, ['alpha', 'beta', 'gamma'])
+
+    resolution('a', 'b', 'c', x=1, y=2, z=3)
+
+    router.resolve.assert_called_once_with('alpha.beta.gamma')
+
+    method.assert_called_once_with(owner, 'a', 'b', 'c', x=1, y=2, z=3)

--- a/tests/unit/api/routing/test_router.py
+++ b/tests/unit/api/routing/test_router.py
@@ -1,0 +1,72 @@
+import pytest
+import six
+
+from threatresponse.api.routing import Router
+
+
+def test_new():
+    router, register = Router.new()
+
+    assert isinstance(router, Router)
+    assert callable(register)
+
+    # Check that `register` is an instance method bound to `router`.
+    self_attr = 'im_self' if six.PY2 else '__self__'
+    assert getattr(register, self_attr) is router
+
+
+def test_register_resolve():
+    router, register = Router.new()
+
+    def a(): pass
+    def ab(): pass
+    def abc(): pass
+
+    # Check that `register` returns a function and can be used as a decorator.
+    register('a')(a)
+    register('a.b')(ab)
+    register('a.b.c')(abc)
+
+    with pytest.raises(ValueError):
+        register('a.b')(ab)
+
+    # Check that `router` gets populated behind the scenes.
+    assert router._routes == {'a': a, 'a.b': ab, 'a.b.c': abc}
+
+    assert router.resolve('a') is a
+    assert router.resolve('a.b') is ab
+    assert router.resolve('a.b.c') is abc
+
+    with pytest.raises(ValueError):
+        router.resolve('a.b.c.d')
+
+
+def test_merged():
+    def a_x(): pass
+    def b_x(): pass
+    def b_y(): pass
+    def c_y(): pass
+
+    x = Router({'a': a_x, 'b': b_x})
+    y = Router({'b': b_y, 'c': c_y})
+
+    # Check that `merged` expects instances of `Router` or at least `None`.
+
+    with pytest.raises(TypeError):
+        Router.merged(x, {})
+
+    with pytest.raises(TypeError):
+        Router.merged({}, y)
+
+    # Check that `merged` always returns a new instance.
+
+    z = Router.merged(x, None)
+    assert z is not x and z._routes == x._routes
+
+    z = Router.merged(None, y)
+    assert z is not y and z._routes == y._routes
+
+    # Check that `merged` preserves the resolution order.
+
+    z = Router.merged(x, y)
+    assert z._routes == {'a': a_x, 'b': b_x, 'c': c_y}

--- a/tests/unit/api/routing/test_router.py
+++ b/tests/unit/api/routing/test_router.py
@@ -70,3 +70,6 @@ def test_merged():
 
     z = Router.merged(x, y)
     assert z._routes == {'a': a_x, 'b': b_x, 'c': c_y}
+
+    z = Router.merged(y, x)
+    assert z._routes == {'a': a_x, 'b': b_y, 'c': c_y}

--- a/tests/unit/api/test_response.py
+++ b/tests/unit/api/test_response.py
@@ -1,0 +1,102 @@
+import pytest
+from mock import MagicMock
+
+from threatresponse.api.response import ResponseAPI
+
+
+def test_respond_observables_succeeds():
+    response = MagicMock()
+
+    request = MagicMock()
+    request.post.return_value = response
+
+    payload = {'foo': 'bar'}
+
+    api = ResponseAPI(request)
+    api.respond.observables(payload)
+
+    request.post.assert_called_once_with(
+        '/iroh/iroh-response/respond/observables',
+        json=payload,
+    )
+
+    response.json.assert_called_once_with()
+
+
+def test_respond_observables_fails():
+    class TestError(Exception):
+        pass
+
+    response = MagicMock()
+    response.raise_for_status.side_effect = TestError('Oops!')
+
+    request = MagicMock()
+    request.post.return_value = response
+
+    payload = {'foo': 'bar'}
+
+    api = ResponseAPI(request)
+    with pytest.raises(TestError):
+        api.respond.observables(payload)
+
+    request.post.assert_called_once_with(
+        '/iroh/iroh-response/respond/observables',
+        json=payload,
+    )
+
+    response.raise_for_status.assert_called_once_with()
+
+
+def test_respond_trigger_succeeds():
+    response = MagicMock()
+
+    request = MagicMock()
+    request.post.return_value = response
+
+    api = ResponseAPI(request)
+    api.respond.trigger(
+        'Monty Python!',
+        'x|y&z',
+        'spam',
+        'eggs',
+        x=1, y=2, z=3,  # extra params
+    )
+
+    request.post.assert_called_once_with(
+        '/iroh/iroh-response/respond/trigger/Monty%20Python%21/x%7Cy%26z',
+        params={'x': 1, 'y': 2, 'z': 3,
+                'observable_type': 'spam',
+                'observable_value': 'eggs'},
+    )
+
+    response.json.assert_called_once_with()
+
+
+def test_respond_trigger_fails():
+    class TestError(Exception):
+        pass
+
+    response = MagicMock()
+    response.raise_for_status.side_effect = TestError('Oops!')
+
+    request = MagicMock()
+    request.post.return_value = response
+
+    api = ResponseAPI(request)
+    with pytest.raises(TestError):
+        api.respond.trigger(
+            'Monty Python!',
+            'x|y&z',
+            'spam',
+            'eggs',
+            x=1, y=2, z=3,  # extra params
+        )
+
+    request.post.assert_called_once_with(
+        '/iroh/iroh-response/respond/trigger/Monty%20Python%21/x%7Cy%26z',
+        params={'x': 1, 'y': 2, 'z': 3,
+                'observable_type': 'spam',
+                'observable_value': 'eggs'},
+    )
+
+    response.raise_for_status.assert_called_once_with()

--- a/threatresponse/api/__init__.py
+++ b/threatresponse/api/__init__.py
@@ -1,3 +1,4 @@
 # Make the classes below importable from the `.api` subpackage directly.
 from .enrich import EnrichAPI
 from .inspect import InspectAPI
+from .response import ResponseAPI

--- a/threatresponse/api/base.py
+++ b/threatresponse/api/base.py
@@ -28,7 +28,7 @@ class API(object):
 
         if router is None:
             raise Exception(
-                "Couldn't build a resolution for {}.".format(type(self))
+                'Could not build a resolution for {}.'.format(type(self))
             )
 
         return Resolution(self, router)

--- a/threatresponse/api/enrich.py
+++ b/threatresponse/api/enrich.py
@@ -1,5 +1,5 @@
-from .routing import Router
 from .base import API
+from .routing import Router
 
 
 class EnrichAPI(API):

--- a/threatresponse/api/inspect.py
+++ b/threatresponse/api/inspect.py
@@ -1,5 +1,5 @@
-from .routing import Router
 from .base import API
+from .routing import Router
 
 
 class InspectAPI(API):

--- a/threatresponse/api/response.py
+++ b/threatresponse/api/response.py
@@ -1,0 +1,51 @@
+from six.moves.urllib.parse import quote
+
+from .base import API
+from .routing import Router
+
+
+class ResponseAPI(API):
+    __router, route = Router.new()
+
+    @route('respond.observables')
+    def _perform(self, payload):
+        """
+        https://visibility.amp.cisco.com/iroh/iroh-response/index.html#!/Response/post_iroh_iroh_response_respond_observables
+        """
+
+        response = self._request.post(
+            '/iroh/iroh-response/respond/observables',
+            json=payload,
+        )
+        print('URL', response.request.url)
+        response.raise_for_status()
+        return response.json()
+
+    @route('respond.trigger')
+    def _perform(self,
+                 module_name,
+                 action_id,
+                 observable_type,
+                 observable_value,
+                 **query):
+        """
+        https://visibility.amp.cisco.com/iroh/iroh-response/index.html#!/Response/post_iroh_iroh_response_respond_trigger_module_name_action_id
+        """
+
+        endpoint = '/iroh/iroh-response/respond/trigger/{}/{}'.format(
+            quote(module_name),
+            quote(action_id),
+        )
+
+        # Extend optional module-specific query params with the required ones.
+        query.update({
+            'observable_type': observable_type,
+            'observable_value': observable_value,
+        })
+
+        response = self._request.post(
+            endpoint,
+            params=query,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/threatresponse/api/response.py
+++ b/threatresponse/api/response.py
@@ -17,7 +17,6 @@ class ResponseAPI(API):
             '/iroh/iroh-response/respond/observables',
             json=payload,
         )
-        print('URL', response.request.url)
         response.raise_for_status()
         return response.json()
 

--- a/threatresponse/api/response.py
+++ b/threatresponse/api/response.py
@@ -31,7 +31,7 @@ class ResponseAPI(API):
         https://visibility.amp.cisco.com/iroh/iroh-response/index.html#!/Response/post_iroh_iroh_response_respond_trigger_module_name_action_id
         """
 
-        endpoint = '/iroh/iroh-response/respond/trigger/{}/{}'.format(
+        url = '/iroh/iroh-response/respond/trigger/{}/{}'.format(
             quote(module_name),
             quote(action_id),
         )
@@ -42,9 +42,6 @@ class ResponseAPI(API):
             'observable_value': observable_value,
         })
 
-        response = self._request.post(
-            endpoint,
-            params=query,
-        )
+        response = self._request.post(url, params=query)
         response.raise_for_status()
         return response.json()

--- a/threatresponse/api/routing/__init__.py
+++ b/threatresponse/api/routing/__init__.py
@@ -1,2 +1,3 @@
-from .router import Router
+# Make the classes below importable from the `.routing` subpackage directly.
 from .resolution import Resolution
+from .router import Router

--- a/threatresponse/api/routing/resolution.py
+++ b/threatresponse/api/routing/resolution.py
@@ -5,8 +5,8 @@ class Resolution(object):
 
     def __init__(self, owner, router, route=None):
         self._owner = owner
-        self._route = route or []
         self._router = router
+        self._route = route or []
 
     def __call__(self, *args, **kwargs):
         """ Invokes a method by the built route. """

--- a/threatresponse/api/routing/router.py
+++ b/threatresponse/api/routing/router.py
@@ -13,7 +13,7 @@ class Router(object):
         def register(method):
             if route in self._routes:
                 raise ValueError(
-                    "Route {} has already been registered.".format(repr(route))
+                    'Route {} has already been registered.'.format(repr(route))
                 )
 
             self._routes[route] = method
@@ -28,9 +28,9 @@ class Router(object):
         """ Returns a method by the specified route. """
 
         if not route:
-            raise ValueError("Route cannot be empty.")
+            raise ValueError('Route cannot be empty.')
         if route not in self._routes:
-            raise ValueError("Route {} is not registered.".format(repr(route)))
+            raise ValueError('Route {} is not registered.'.format(repr(route)))
 
         return self._routes[route]
 
@@ -38,7 +38,7 @@ class Router(object):
     def merged(x, y):
         """ Merges two instances of `Router` into a single one. """
 
-        message = "Expected {} to be of type {}, but got {}."
+        message = 'Expected {} to be of type {}, but got {}.'
 
         if x is not None and not isinstance(x, Router):
             raise TypeError(message.format(repr('x'), Router, type(x)))

--- a/threatresponse/client.py
+++ b/threatresponse/client.py
@@ -1,5 +1,6 @@
 from .api.enrich import EnrichAPI
 from .api.inspect import InspectAPI
+from .api.response import ResponseAPI
 from .request.authorized import AuthorizedRequest
 from .request.logged import LoggedRequest
 from .request.relative import RelativeRequest
@@ -22,6 +23,7 @@ class ThreatResponse(object):
 
         self._inspect = InspectAPI(request)
         self._enrich = EnrichAPI(request)
+        self._response = ResponseAPI(request)
 
     @property
     def inspect(self):
@@ -30,3 +32,7 @@ class ThreatResponse(object):
     @property
     def enrich(self):
         return self._enrich
+
+    @property
+    def response(self):
+        return self._response


### PR DESCRIPTION
[/iroh/iroh-response/respond/sighting](https://visibility.amp.cisco.com/iroh/iroh-response/index.html#!/Response/post_iroh_iroh_response_respond_sighting) seems to be deprecated and is not covered here.