### PR TITLE
Add verdict and target basic test cases

### DIFF
--- a/tests/functional/tests/test_ctia_api.py
+++ b/tests/functional/tests/test_ctia_api.py
@@ -48,7 +48,7 @@ def module_tool_client():
     )
 
 
-SERVER_VERSION = '1.0.11'
+SERVER_VERSION = '1.0.14'
 
 
 def test_python_module_ctia_positive_actor(module_headers, module_tool_client):
@@ -415,7 +415,8 @@ def test_python_module_ctia_positive_campaign(
     get_tool_response = campaign.get(entity_id)
     assert get_tool_response['title'] == 'New demo campaign'
     # Search for campaign by entity id
-    search_tool_response = campaign.search(params={'query': entity_id})
+    search_tool_response = campaign.search(params={
+        'query': 'id:*{}'.format(entity_id)})
     # We got exactly one entry for provided unique entity id
     assert len(search_tool_response) == 1
     assert search_tool_response[0]['title'] == 'New demo campaign'


### PR DESCRIPTION
Fix existing tests and add few more test cases for verdict and targets commands

```
py.test 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.5, pytest-5.1.0, py-1.8.0, pluggy-0.12.0
rootdir: /home/ashtayer/Desktop/ctr/tr-05-api-module, inifile: pytest.ini
plugins: pep8-1.0.6, repeat-0.8.0
collected 36 items                                                                                                                                                                           

tests/test_ctia_api.py ........................                                                                                                                                        [ 66%]
tests/test_ctr_05_api.py ............                                                                                                                                                  [100%]

=============================================================================== 36 passed in 150.01s (0:02:30) ============================================================================
```